### PR TITLE
(For Vik/Duy) Switching XCom serialization logic (re-do on 1.10.x branch)

### DIFF
--- a/airflow/models.py
+++ b/airflow/models.py
@@ -62,7 +62,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.ext.declarative import declarative_base, declared_attr
 from sqlalchemy.orm import reconstructor, relationship, synonym
-import sqlalchemy.types as types
+from sqlalchemy import types
 
 from croniter import (
     croniter, CroniterBadCronError, CroniterBadDateError, CroniterNotAlphaError
@@ -4709,15 +4709,15 @@ class SerializingLargeBinary(types.TypeDecorator):
     def process_result_value(self, value, dialect):
         enable_pickling = configuration.getboolean('core', 'enable_xcom_pickling')
         if enable_pickling:
-            return pickle.loads(self.value)
+            return pickle.loads(value)
         else:
             try:
-                return json.loads(self.value.decode('UTF-8'))
+                return json.loads(value.decode('UTF-8'))
             except (UnicodeEncodeError, ValueError):
                 # For backward-compatibility.
                 # Preventing errors in webserver
                 # due to XComs mixed with pickled and unpickled.
-                return pickle.loads(self.value)
+                return pickle.loads(value)
 
 
 class XCom(Base, LoggingMixin):

--- a/airflow/version.py
+++ b/airflow/version.py
@@ -18,4 +18,4 @@
 # under the License.
 #
 
-version = '1.10.2'
+version = '1.10.2-siftpatch1'


### PR DESCRIPTION
This is a redo of https://github.com/SiftScience/airflow/pull/1 based on the 1.10.x branch (v1-10-stable)

**Purpose:**
- https://github.com/SiftScience/code/issues/31076
- XCom data serialization works fine with all API calls except for when writing from the Admin UI. This should fix it (and, in certain ways, clean up the serialization logic in the SQLAlchemy model)

**Technical overview:**
- The SQLAlchemy model says that the "data" field in the `xcom` table is a binary field. It is populated with either a pickled version of an object (legacy mode, but the one we use), or an UTF-8-encoded json string.
- The way this translation happens is by making sure that all the set and get operations go through some transformation function. And that works for most use cases, except for the Admin UI, which uses `flask-admin` and goes directly from the form to the SQLAlchemy model. That means that it tries to write a string into a binary field.
- The actual solution is to not call it a binary field, but some type we control and then provide a serialization/deserialization in the type format itself. This means that we don't have to deal with doing serialization/deserialization in the getters/setters, which have also been removed.
- Also bumped the version to `1.10.2-siftpatch1` which will be used for deployment

**Testing/deployment plan:**
- Tested with our docker setup and a local PyPI repository and all XCom behavior worked (create, update on UI, push and pull from python)
- Confirmed that it works with a PyPI repository. Just need to set up one (that is not my laptop).
- Tried to run the unit tests, but was unable to do it.

I've actually made a mistake and sent this PR to Airflow's master, which actually triggered their test run and failed (https://travis-ci.org/apache/airflow/builds/486019674?utm_source=github_status&utm_medium=notification). Here are the failing tests:

```
[error] 0.01% tests.TaskInstanceTest.test_xcom_pull_after_success: 0.1624s
[error] 0.00% tests.TaskInstanceTest.test_xcom_pull_different_execution_date: 0.0702s
[error] 0.00% tests.lineage.test_lineage.TestLineage.test_lineage: 0.0343s
[error] 0.00% tests.TaskInstanceTest.test_xcom_pull: 0.0265s
[error] 0.00% tests.ClearTasksTest.test_xcom_disable_pickle_type_fail_on_non_json: 0.0087s
```

I'll see if I can run them locally and figure out what is going on. My guess is that it's the test case depending on something that I moved around and not the code, but I'll only find out when I look into it.