### PR TITLE
Patching [AIRFLOW-6728] into the non-RBAC webserver

### DIFF
--- a/airflow/task/task_runner/standard_task_runner.py
+++ b/airflow/task/task_runner/standard_task_runner.py
@@ -25,7 +25,8 @@ from setproctitle import setproctitle
 from airflow.task.task_runner.base_task_runner import BaseTaskRunner
 from airflow.utils.helpers import reap_process_group
 
-CAN_FORK = hasattr(os, 'fork')
+# Disable forking https://github.com/apache/airflow/pull/6627#issuecomment-640178886
+CAN_FORK = False  # hasattr(os, 'fork')
 
 
 class StandardTaskRunner(BaseTaskRunner):

--- a/airflow/version.py
+++ b/airflow/version.py
@@ -18,4 +18,4 @@
 # under the License.
 #
 
-version = '1.10.10-siftpatch1'
+version = '1.10.10-siftpatch2'

--- a/airflow/version.py
+++ b/airflow/version.py
@@ -18,4 +18,4 @@
 # under the License.
 #
 
-version = '1.10.10'
+version = '1.10.10-siftpatch1'

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -393,7 +393,7 @@
           container: "body",
         });
       });
-      d3.json("{{ url_for('airflow.task_stats') }})
+      d3.json("{{ url_for('airflow.task_stats') }}")
         .header("X-CSRFToken", "{{ csrf_token() }}")
         .post(encoded_dag_ids, function(error, json) {
         for(var dag_id in json) {

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -249,11 +249,11 @@
         return false;
       }
 
-      var encoded_dag_ids = [];
+      var encoded_dag_ids = new URLSearchParams();
 
       $.each($("[id^=toggle]"), function(i, v) {
         var dag_id = $(v).attr('dag_id');
-        encoded_dag_ids.push(encodeURIComponent(dag_id));
+        encoded_dag_ids.append('dag_ids', dag_id);
 
         $(v).change (function() {
           if ($(v).prop('checked')) {
@@ -393,7 +393,9 @@
           container: "body",
         });
       });
-      d3.json("{{ url_for('airflow.task_stats') }}?dag_ids=" + (encoded_dag_ids.join(',')), function(error, json) {
+      d3.json("{{ url_for('airflow.task_stats') }})
+        .header("X-CSRFToken", "{{ csrf_token() }}")
+        .post(encoded_dag_ids, function(error, json) {
         for(var dag_id in json) {
             states = json[dag_id];
             g = d3.select('svg#task-run-' + dag_id.replace(/\./g, '__dot__'))

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -602,7 +602,7 @@ class Airflow(AirflowViewMixin, BaseView):
                 })
         return wwwutils.json_response(payload)
 
-    @expose('/task_stats')
+    @expose('/task_stats', methods=['POST'])
     @login_required
     @provide_session
     def task_stats(self, session=None):
@@ -610,9 +610,9 @@ class Airflow(AirflowViewMixin, BaseView):
         DagRun = models.DagRun
         Dag = models.DagModel
 
-        # Filter by get parameters
+        # Filter by post parameters
         selected_dag_ids = {
-            unquote(dag_id) for dag_id in request.args.get('dag_ids', '').split(',') if dag_id
+            unquote(dag_id) for dag_id in request.form.getlist('dag_ids') if dag_id
         }
 
         LastDagRun = (


### PR DESCRIPTION
The patch discussed in https://github.com/apache/airflow/issues/8636 was merged to 1.10.10 in https://github.com/SiftScience/airflow/commit/874207a5cc189547b5c6f8119d75d066defff8bf, but it actually only includes the `www_rbac` code and not the `www` code. This tries to merge that into the `www` code.

This is pretty much the same thing that is running today on the Airflow adhoc as patched locally, so it works for the things that I've tested. I haven't seen any other places that call `task_stats`