### PR TITLE
Patche to allow gcp_container_operator to use key file to authenticate to gke

### DIFF
--- a/airflow/contrib/operators/gcp_container_operator.py
+++ b/airflow/contrib/operators/gcp_container_operator.py
@@ -230,10 +230,12 @@ class GKEPodOperator(KubernetesPodOperator):
                  location,
                  cluster_name,
                  gcp_conn_id='google_cloud_default',
+                 gcp_credentials=None,
                  *args,
                  **kwargs):
         super(GKEPodOperator, self).__init__(*args, **kwargs)
         self.project_id = project_id
+        self.gcp_credentials = gcp_credentials
         self.location = location
         self.cluster_name = cluster_name
         self.gcp_conn_id = gcp_conn_id
@@ -258,6 +260,14 @@ class GKEPodOperator(KubernetesPodOperator):
         # This is to avoid race conditions of reading/writing a single file
         with tempfile.NamedTemporaryFile() as conf_file:
             os.environ[KUBE_CONFIG_ENV_VAR] = conf_file.name
+
+            if self.gcp_credentials is not None:
+                # This solves most cases when we are logged in using the service key in Airflow.
+                # Don't display stdout/stderr for security reason
+                subprocess.check_call([
+                    "gcloud", "auth", "activate-service-account", "--key-file=%s" % self.gcp_credentials,
+                ])
+
             # Attempt to get/update credentials
             # We call gcloud directly instead of using google-cloud-python api
             # because there is no way to write kubernetes config to a file, which is


### PR DESCRIPTION
**Purpose**
* Patches airflow to allow credentials files to be used for GKE authentication

**Technical overview**
* Runs `gcloud auth activate-service-account` using a keyfile when specified
* This requires a patch because the gcp_pod_operator uses a temp dir for it's gcloud config dir, which cannot be captured from outside of the operator

**Testing**
Tested very similar code in staging with a copied patch

**Deployment plan**
This will require a deploy to airflow, which will have to be requested from data platform team