### PR TITLE
(For Matt) DP-2443 - Fix a merge difference for security patch

### DIFF
--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -61,8 +61,8 @@ app = Celery(
 
 @app.task
 def execute_command(command_to_exec):
-    if command_to_exec[0:3] != ["airflow", "tasks", "run"]:
-        raise ValueError('The command must start with ["airflow", "tasks", "run"].')
+    if command_to_exec[0:2] != ["airflow", "run"]:
+        raise ValueError('The command must start with ["airflow", "run"].')
 
     log = LoggingMixin().log
     log.info("Executing command in Celery: %s", command_to_exec)

--- a/airflow/executors/dask_executor.py
+++ b/airflow/executors/dask_executor.py
@@ -64,8 +64,8 @@ class DaskExecutor(BaseExecutor):
                 'All tasks will be run in the same cluster'
             )
 
-        if command[0:3] != ["airflow", "tasks", "run"]:
-            raise ValueError('The command must start with ["airflow", "tasks", "run"].')
+        if command[0:2] != ["airflow", "run"]:
+            raise ValueError('The command must start with ["airflow", "run"].')
 
         def airflow_run():
             return subprocess.check_call(command, close_fds=True)

--- a/airflow/executors/local_executor.py
+++ b/airflow/executors/local_executor.py
@@ -225,8 +225,8 @@ class LocalExecutor(BaseExecutor):
         self.impl.start()
 
     def execute_async(self, key, command, queue=None, executor_config=None):
-        if command[0:3] != ["airflow", "tasks", "run"]:
-            raise ValueError('The command must start with ["airflow", "tasks", "run"].')
+        if command[0:2] != ["airflow", "run"]:
+            raise ValueError('The command must start with ["airflow", "run"].')
 
         self.impl.execute_async(key=key, command=command)
 

--- a/airflow/executors/sequential_executor.py
+++ b/airflow/executors/sequential_executor.py
@@ -38,8 +38,8 @@ class SequentialExecutor(BaseExecutor):
         self.commands_to_run = []
 
     def execute_async(self, key, command, queue=None, executor_config=None):
-        if command[0:3] != ["airflow", "tasks", "run"]:
-            raise ValueError('The command must start with ["airflow", "tasks", "run"].')
+        if command[0:2] != ["airflow", "run"]:
+            raise ValueError('The command must start with ["airflow", "run"].')
 
         self.commands_to_run.append((key, command,))
 


### PR DESCRIPTION
cc: @schnood 

## Purpose:
- https://sift.atlassian.net/browse/DP-2443
- When testing the change in https://github.com/SiftScience/airflow/pull/7 I realized it wasn't working because it couldn't validate the execution
- Looking more into the actual change, I based on the changed checked into Airflow master (https://github.com/apache/airflow/pull/9178), but the actual change in the 1.10.x branch was https://github.com/apache/airflow/commit/0a955b6752c3d805b280c1f76f7f83606d2ab916
- So this fixes the change to the correct one in Airflow 1.10.x

## Technical overview:
- Correctly apply the change

## Testing plan:
- [x] This PR contains all required labels and reviewers as per our [Change Management Procedure](https://paper.dropbox.com/doc/Change-Management-Procedure--AaNgGK8kKaT7WkLgDgPbFIDnAg-IvGDETLPhSFM3t6198IhG#:uid=669926417316840&h2=Types-of-Review-for-Changes)
- This time I tested on the local docker and it actually schedules things

## Deployment plan:
- Once merged, I'll deploy to our PyPI repo
- Another PR will then be sent to update salt to use that version. Once that happens, Airflow will update to this version by salt
- Once that update is done, we have to restart the Airflow processes (salt will not do that) 

## Rollback plan:
- Roll back on salt to 1.10.10-siftpatch2 and deprecate siftpatch3
- Note that siftpatch3 will also pick up the changes by @mlegore in https://github.com/SiftScience/airflow/pull/6 so we may have to create a siftpatch4 with just his changes (reverting this change) so that we don't get regression for his feature.

## Customer Impact Assessment:
- as per our [Change Management Procedure](https://paper.dropbox.com/doc/Change-Management-Procedure--AaNgGK8kKaT7WkLgDgPbFIDnAg-IvGDETLPhSFM3t6198IhG#:uid=669926417316840&h2=Types-of-Review-for-Changes)
- Severity 3: Airflow is used for some background functionality like model training and backups, but none of them are directly visible by customers