### PR TITLE
(for Michel) pep 440 compliant package name

### DIFF
--- a/airflow/version.py
+++ b/airflow/version.py
@@ -18,4 +18,4 @@
 # under the License.
 #
 
-version = '1.10.10-siftpatch3'
+version = '1.10.10+siftpatch4'


### PR DESCRIPTION
## Description
- closes https://sift.atlassian.net/browse/CI-6919

- No function change in airflow; just a packaging change to conform to now-enforced PEP 440 package name constraints.

## Build, package and testing
(built on stg1; prod build also completed.)
### Build
Built with:

- build a venv
  - pip install
    - gitpython
    - wheel
    - twine
- python setup.up clean

then
```
(venv-build-sift-airflow) ❯ python setup.py sdist                                                       jeff-pep-440-compliant-package-name …
  ...
copying scripts/upstart/airflow-worker.conf -> apache-airflow-1.10.10+siftpatch4/scripts/upstart
Writing apache-airflow-1.10.10+siftpatch4/setup.cfg
creating dist
Creating tar archive
removing 'apache-airflow-1.10.10+siftpatch4' (and everything under it)
```
### Package
Use twine
First register our local pypi server (stg1)
```
(venv-build-sift-airflow) ❯ python -m twine register \
  --repository-url http://pypiserver.stg1.useast1.int.siftscience.com:8080/ \
  --username sift \
  --password THE_SIFT_PYPI_PASSWORD_HERE \
  dist/apache_airflow-1.10.10+siftpatch4-py2.py3-none-any.whl
Registering package to http://pypiserver.stg1.useast1.int.siftscience.com:8080/
Registering apache_airflow-1.10.10+siftpatch4-py2.py3-none-any.whl
```

then upload:
```
(venv-build-sift-airflow) ❯ python -m twine upload \                                                    jeff-pep-440-compliant-package-name …
  --repository-url http://pypiserver.stg1.useast1.int.siftscience.com:8080/ \
  --username sift \
  --password THE_SIFT_PYPI_PASSWORD_HERE \
  dist/*
```

and finally, install it:
```
pip install \
  --extra-index-url http://pypiserver.stg1.useast1.int.siftscience.com:8080 \
  --trusted-host pypiserver.stg1.useast1.int.siftscience.com \
  apache-airflow==1.10.10+siftpatch4
```